### PR TITLE
Add RoboSkin ROS 2 tactile starter toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 
 ## Toolkits
 
+- [x] RoboSkin ROS 2 Tactile Starter Kit [[Project Link]](https://roboskin.ai/guides/ros2-tactile-sensing) [2026]
 - [x] PyRep: Bringing V-REP to Deep Robot Learning [[Paper Link]](https://arxiv.org/abs/1906.11176) [[Project Link]](https://github.com/stepjam/PyRep) [2024]
 - [x] Yet Another Robotics and Reinforcement learning framework for PyTorch [[Project Link]](https://github.com/stepjam/YARR) [2024]
 


### PR DESCRIPTION
## Summary

Adds the RoboSkin ROS 2 Tactile Starter Kit to the Toolkits section.

The project provides an Apache-2.0, hardware-neutral ROS 2 reference for a typed tactile-array message contract, deterministic synthetic publishing, validation, and rosbag2 record/replay configuration.

## Evidence and maintenance

- Code: https://github.com/roboskin-ai/ros2-tactile-starter-kit
- Versioned release: https://github.com/roboskin-ai/ros2-tactile-starter-kit/releases/tag/v0.1.0
- Successful CI run: https://github.com/roboskin-ai/ros2-tactile-starter-kit/actions/runs/32648006098
- Project guide: https://roboskin.ai/guides/ros2-tactile-sensing

All bundled values are synthetic. The project makes no hardware-performance, latency, accuracy, force-range, sampling-rate, or robustness claim.

I maintain RoboSkin.ai and the linked starter kit. This submission is not a request for endorsement or reciprocal linking.

## Checklist

- [x] Checked for duplicates
- [x] Verified the project and code links
- [x] Used the public release year
- [x] Ran `python scripts/check_readme.py` successfully (with `PYTHONUTF8=1` on Windows)