### PR TITLE
Add OmniSim simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 - [ ] Automated Discovery of Semantic Attacks in Multi-Robot Navigation [[Paper Link]](https://www.usenix.org/conference/usenixsecurity25/presentation/yeke) [2025]
 - [ ] SkillJect: Automating Stealthy Skill-Based Prompt Injection for Coding Agents [[Paper Link]](https://arxiv.org/abs/2602.14211) [2026]
 
-## Simulators
+
 
 - [x] SIMPLE: Simulation-Based Policy Learning and Evaluation for Humanoid Loco-manipulation [[Paper Link]](https://arxiv.org/abs/2606.08278) [[Project Link]](https://github.com/physical-superintelligence-lab/SIMPLE) [2026]
 - [ ] An Embodied Simulation Platform, Benchmark, and Data-Efficient Augmentation Framework for Wet-Lab Robotics [[Paper Link]](https://arxiv.org/abs/2606.12936) [2026]

--- a/README.md
+++ b/README.md
@@ -510,7 +510,9 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 - [ ] Automated Discovery of Semantic Attacks in Multi-Robot Navigation [[Paper Link]](https://www.usenix.org/conference/usenixsecurity25/presentation/yeke) [2025]
 - [ ] SkillJect: Automating Stealthy Skill-Based Prompt Injection for Coding Agents [[Paper Link]](https://arxiv.org/abs/2602.14211) [2026]
 
+## Simulators
 
+- [x] OmniSim [[Project Link]](https://github.com/omnilink-tech/omnisim) [2026]
 
 - [x] SIMPLE: Simulation-Based Policy Learning and Evaluation for Humanoid Loco-manipulation [[Paper Link]](https://arxiv.org/abs/2606.08278) [[Project Link]](https://github.com/physical-superintelligence-lab/SIMPLE) [2026]
 - [ ] An Embodied Simulation Platform, Benchmark, and Data-Efficient Augmentation Framework for Wet-Lab Robotics [[Paper Link]](https://arxiv.org/abs/2606.12936) [2026]


### PR DESCRIPTION
## Summary

- Adds OmniSim to the Simulators section as a public project-only simulator entry.
- Uses the repository root as the stable project link and the project year.

OmniSim is an Apache-2.0 robotics simulator with agent-facing HTTP/JSON and MCP control, native URDF import, synthetic-data tooling, and benchmark suites.

Disclosure: this is a self-submission from the OmniLink maintainers. Windows is currently the beta platform, Linux is a source build, macOS is not in beta, ROS 2 support covers base topics only, and we make no physical-transfer claim.

## Checklist

- [x] I checked for duplicates in the target section.
- [x] I verified the project/code/dataset link.
- [x] I used the correct year.
- [x] Paper-link check is not applicable because this is a project-only simulator entry.
- [ ] I did not run `python scripts/check_readme.py` locally; the final diff is limited to the required entry and one separating blank line.