### PR TITLE
docs: add Provael to Toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 ## Toolkits
 
 - [x] RoboSkin ROS 2 Tactile Starter Kit [[Project Link]](https://roboskin.ai/guides/ros2-tactile-sensing) [2026]
+- [x] Provael: Red-team Open Vision-Language-Action Policies in Simulation [[Project Link]](https://github.com/provael/provael) [2026]
 - [x] PyRep: Bringing V-REP to Deep Robot Learning [[Paper Link]](https://arxiv.org/abs/1906.11176) [[Project Link]](https://github.com/stepjam/PyRep) [2024]
 - [x] Yet Another Robotics and Reinforcement learning framework for PyTorch [[Project Link]](https://github.com/stepjam/YARR) [2024]
 


### PR DESCRIPTION
One entry under Toolkits, per CONTRIBUTING.md ("Add a missing paper, dataset, simulator, benchmark, toolkit, or project page").

```md
- [x] Provael: Red-team Open Vision-Language-Action Policies in Simulation [[Project Link]](https://github.com/provael/provael) [2026]
```

Adversarial evaluation harness for open VLA policies. Runs attack suites against a policy in LIBERO and reports an Attack Success Rate against a benign control arm, with SARIF output. CPU-only, Apache-2.0.

Checked against the guide:

- Not already in the README (searched for `provael`).
- `[x]` because there is a public repo.
- No `Paper Link`: there is no paper, so it is omitted rather than left as a placeholder.
- `[2026]` is the release year. Placed next to RoboSkin to keep the 2026 entries together, happy to move it if you order Toolkits differently.
- Single section, no duplicate entry elsewhere.

Not attached to the placement. If you would rather it sat under Safety than Toolkits, say so and I will move it.