### PR TITLE
Add mlx-smolvla (MLX-native SmolVLA runtime for Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 
 ## Toolkits
 
+- [x] mlx-smolvla [[Project Link]](https://github.com/daniiarabdiev/mlx-smolvla) [2026]
 - [x] RoboSkin ROS 2 Tactile Starter Kit [[Project Link]](https://roboskin.ai/guides/ros2-tactile-sensing) [2026]
 - [x] Provael: Red-team Open Vision-Language-Action Policies in Simulation [[Project Link]](https://github.com/provael/provael) [2026]
 - [x] PyRep: Bringing V-REP to Deep Robot Learning [[Paper Link]](https://arxiv.org/abs/1906.11176) [[Project Link]](https://github.com/stepjam/PyRep) [2024]


### PR DESCRIPTION
Adds mlx-smolvla, my publicly available MLX-native SmolVLA runtime, to Toolkits using the project-link format. Its scope is Apple Silicon checkpoint inference, LeRobot-protocol serving, and preview LoRA training with PyTorch parity checks; training remains a research preview and task-level hardware success is not claimed.

https://github.com/daniiarabdiev/mlx-smolvla

Prior art: tokimoa/smolvla-mlx (Hugging Face, 2026-07-29) is an earlier independent inference-only SmolVLA-to-MLX port; tokimoa also published pi0-mlx and groot-n1.7-mlx. The SmolVLM implementation in mlx-vlm was an architecture reference, with no runtime dependency. mlx-smolvla is not a fork of either.
