### PR TITLE
Add Common Behavior Data toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ As embodied AI systems are deployed in safety-critical environments (autonomous 
 - [x] Provael: Red-team Open Vision-Language-Action Policies in Simulation [[Project Link]](https://github.com/provael/provael) [2026]
 - [x] PyRep: Bringing V-REP to Deep Robot Learning [[Paper Link]](https://arxiv.org/abs/1906.11176) [[Project Link]](https://github.com/stepjam/PyRep) [2024]
 - [x] Yet Another Robotics and Reinforcement learning framework for PyTorch [[Project Link]](https://github.com/stepjam/YARR) [2024]
+- [x] Common Behavior Data [[Project Link]](https://github.com/Koichi3333/common-behavior-data) [2026]
 
 ## Citation
 


### PR DESCRIPTION
## Summary

- Added Common Behavior Data to the Toolkits section.
- Common Behavior Data is an open framework for turning observed behavior into reusable assets across simulators, robots, models, and tools.
- It currently includes generators, adapters for MuJoCo, Unity, and Isaac Sim / Unitree G1, examples, experiments, and visual showcases.

Project:
https://github.com/Koichi3333/common-behavior-data

## Checklist

- [x] I checked for duplicates in the target section.
- [x] Paper link: N/A — this is a toolkit/project repository.
- [x] I verified the project/code/dataset link.
- [x] I used the correct year.
- [x] I ran `python scripts/check_readme.py`.
